### PR TITLE
Update upload-pages-artifact from v3 to v4 to fix SHA pinning policy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: './build'
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
v3 internally references actions/upload-artifact@v4 by tag, which violates the org policy requiring all actions pinned to full-length commit SHAs. v4 pins it by SHA.