### PR TITLE
Test: SHA pinning enforcement with local actions

### DIFF
--- a/.github/actions/test-local/action.yml
+++ b/.github/actions/test-local/action.yml
@@ -1,0 +1,7 @@
+name: 'Test Local Action'
+description: 'Dummy action to test SHA pinning enforcement with local actions'
+runs:
+  using: 'composite'
+  steps:
+    - run: echo "Local action works!"
+      shell: bash

--- a/.github/workflows/test-sha-pinning.yml
+++ b/.github/workflows/test-sha-pinning.yml
@@ -1,0 +1,17 @@
+name: Test SHA Pinning with Local Actions
+on: workflow_dispatch
+
+jobs:
+  test-relative-path:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Test local action via relative path
+        uses: ./.github/actions/test-local
+
+  test-full-path:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Test local action via full owner/repo path
+        uses: European-Unified-ID/euid-docs-preview/.github/actions/test-local@test-sha-pinning-local-action


### PR DESCRIPTION
Temporary test - will revert after testing. Tests whether local composite actions work under SHA pinning enforcement.